### PR TITLE
Add event medalists relational endpoint

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -81,14 +81,15 @@ task('olympianImport', [], async function () {
 desc('Import all olympianEvent data.')
 task('olympianEventsImport', [], async function () {
   const data = await database('summer_2016')
-    .select('name', 'team', 'age', 'sport', 'event')
-    .groupBy('name', 'team', 'age', 'sport', 'event')
+    .select('name', 'team', 'age', 'sport', 'event', 'medal')
+    .groupBy('name', 'team', 'age', 'sport', 'event', 'medal')
   data.forEach(async function (olympianData) {
     const eventId = await database('events').where('name', olympianData.event)
     const olympianId = await database('olympians').where('name', olympianData.name)
     const olympianEvent = {
       olympian_id: olympianId[0].id,
-      event_id: eventId[0].id
+      event_id: eventId[0].id,
+      medal: olympianData.medal
     }
     console.log(olympianEvent)
     await database('olympian_events').insert(olympianEvent, 'id')

--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const configuration = require('./knexfile')[environment];
 var indexRouter = require('./routes/index');
 var olympiansRouter = require('./routes/api/v1/olympians')
 var eventsRouter = require('./routes/api/v1/events')
+var eventMedalists = require('./routes/api/v1/eventMedalists')
 
 var app = express();
 
@@ -21,5 +22,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter)
 app.use('/api/v1/events', eventsRouter)
+app.use('/api/v1/events/:id/medalists', eventMedalists)
 
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -9,7 +9,6 @@ const configuration = require('./knexfile')[environment];
 var indexRouter = require('./routes/index');
 var olympiansRouter = require('./routes/api/v1/olympians')
 var eventsRouter = require('./routes/api/v1/events')
-var eventMedalists = require('./routes/api/v1/eventMedalists')
 
 var app = express();
 
@@ -22,6 +21,6 @@ app.use(express.static(path.join(__dirname, 'public')));
 app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter)
 app.use('/api/v1/events', eventsRouter)
-app.use('/api/v1/events/:id/medalists', eventMedalists)
+app.use('/api/v1/events', eventsRouter)
 
 module.exports = app;

--- a/db/migrations/20200113191549_olympianEvents.js
+++ b/db/migrations/20200113191549_olympianEvents.js
@@ -5,6 +5,7 @@ exports.up = function(knex) {
       table.increments('id').primary()
       table.integer('event_id').unsigned().references('id').inTable('events')
       table.integer('olympian_id').unsigned().references('id').inTable('olympians')
+      table.string('medal')
     })
   ])
 }

--- a/routes/api/v1/eventMedalists.js
+++ b/routes/api/v1/eventMedalists.js
@@ -1,0 +1,8 @@
+var express = require('express');
+var router = express.Router();
+
+router.get('/', async (request, response) => {
+
+})
+
+module.exports = router;

--- a/routes/api/v1/eventMedalists.js
+++ b/routes/api/v1/eventMedalists.js
@@ -1,8 +1,0 @@
-var express = require('express');
-var router = express.Router();
-
-router.get('/', async (request, response) => {
-
-})
-
-module.exports = router;

--- a/routes/api/v1/events.js
+++ b/routes/api/v1/events.js
@@ -1,11 +1,25 @@
 var express = require('express');
 var router = express.Router();
 
+const environment = process.env.NODE_ENV || 'development'
+const configuration = require('../../../knexfile')[environment]
+const database = require('knex')(configuration)
+
 const SportEvents = require('../../../formatters/sportEventsFormatter')
 
 router.get('/', async (request, response) => {
   const events = await new SportEvents().eventsFormat()
   return response.status(200).json({ events: events })
+})
+
+router.get('/:id/medalists', async (request, response) => {
+  const event = await database('events').where('id', request.params.id)
+  const medalists = await database('olympian_events')
+    .innerJoin('olympians', 'olympian_id', 'olympians.id')
+    .select('olympians.name', 'olympians.team', 'olympians.age', 'olympian_events.medal')
+    .where('olympian_events.event_id', request.params.id)
+    .whereNot('medal', null)
+  response.status(200).json({ event: event[0].name, medalists: medalists })
 })
 
 module.exports = router;

--- a/tests/requests/eventMedalists.spec.js
+++ b/tests/requests/eventMedalists.spec.js
@@ -1,0 +1,80 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+let point3
+
+describe('Test the events path', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table sports cascade')
+    await database.raw('truncate table events cascade')
+    await database.raw('truncate table olympians cascade')
+    await database.raw('truncate table olympianEvents cascade')
+
+    const sport = {
+      name: 'Basketball'
+    }
+
+    await database('sports').insert(sport, 'id')
+
+    const basketball = await database('sports').where('name', await sport.name)
+
+    const event = {
+      name: '3 point contest',
+      sport_id: basketball[0].id
+    }
+    point3 = await database('events').insert(event, 'id')
+
+    const player = {
+      name: 'Tylor',
+      team: 'USA',
+      age: 29,
+      sport: '3 point contest',
+      total_medals_won: 42
+    }
+
+    const tylor = await database('olympians').insert(player, 'id')
+
+    const olympianEvent = {
+      event_id: point3.id,
+      olympian_id: tylor.id,
+      medal: 'Gold'
+    }
+    await database('olympian_events').insert(olympianEvent, 'id')
+  })
+
+  afterEach(() => {
+    database.raw('truncate table sports cascade')
+    database.raw('truncate table events cascade')
+    database.raw('truncate table olympians cascade')
+    database.raw('truncate table olympianEvents cascade')
+  })
+
+  describe('test event medalists GET', () => {
+    it('happy path', async () => {
+      const response = await request(app)
+        .get(`/api/v1/events/${point3}/medalists`)
+
+      const results = response.body
+
+      expect(response.statusCode).toBe(200)
+
+      expect(results.event).toBe('3 point contest')
+      expect(results.medalists.length).toBe(1)
+
+      expect(results.medalists[0]).toHaveProperty('name')
+      expect(results.medalists[0]).toHaveProperty('team')
+      expect(results.medalists[0]).toHaveProperty('age')
+      expect(results.medalists[0]).toHaveProperty('medal')
+
+      expect(results.medalists[0].name).toBe('Tylor')
+      expect(results.medalists[0].team).toBe('USA')
+      expect(results.medalists[0].age).toBe(29)
+      expect(results.medalists[0].medal).toBe('Gold')
+    })
+  })
+})

--- a/tests/requests/eventMedalists.spec.js
+++ b/tests/requests/eventMedalists.spec.js
@@ -13,7 +13,7 @@ describe('Test the events path', () => {
     await database.raw('truncate table sports cascade')
     await database.raw('truncate table events cascade')
     await database.raw('truncate table olympians cascade')
-    await database.raw('truncate table olympianEvents cascade')
+    await database.raw('truncate table olympian_events cascade')
 
     const sport = {
       name: 'Basketball'
@@ -40,8 +40,8 @@ describe('Test the events path', () => {
     const tylor = await database('olympians').insert(player, 'id')
 
     const olympianEvent = {
-      event_id: point3.id,
-      olympian_id: tylor.id,
+      event_id: point3[0],
+      olympian_id: tylor[0],
       medal: 'Gold'
     }
     await database('olympian_events').insert(olympianEvent, 'id')
@@ -51,15 +51,16 @@ describe('Test the events path', () => {
     database.raw('truncate table sports cascade')
     database.raw('truncate table events cascade')
     database.raw('truncate table olympians cascade')
-    database.raw('truncate table olympianEvents cascade')
+    database.raw('truncate table olympian_events cascade')
   })
 
   describe('test event medalists GET', () => {
     it('happy path', async () => {
       const response = await request(app)
-        .get(`/api/v1/events/${point3}/medalists`)
+        .get(`/api/v1/events/${point3[0]}/medalists`)
 
       const results = response.body
+
 
       expect(response.statusCode).toBe(200)
 


### PR DESCRIPTION
# Status
**READY TO DEPLOY**

## Migrations
YES

## Description
This PR adds the api/v1/events/:id/medalists endpoint and testing. All functionality is working as expected and can be merged into master. 

A few notes on this PR:
  * Added new column 'medal' into olympian_events table

## Related PRs

## Todos
- [x] Testing
- [ ] Documentation


## Deploy Notes
There are slight changes to the previous migrations, make sure to rollback and then remigrate when pulling down these changes.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* The `api/v1/events/:id/medalists` endpoint is fully functional
* All new features have been fully tested, passing travis