### PR TITLE
Add olympian_stats endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const configuration = require('./knexfile')[environment];
 
 var indexRouter = require('./routes/index');
 var olympiansRouter = require('./routes/api/v1/olympians')
+var olympianStatsRouter = require('./routes/api/v1/olympianStats')
 var eventsRouter = require('./routes/api/v1/events')
 
 var app = express();
@@ -20,6 +21,7 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', indexRouter);
 app.use('/api/v1/olympians', olympiansRouter)
+app.use('/api/v1/olympian_stats', olympianStatsRouter)
 app.use('/api/v1/events', eventsRouter)
 app.use('/api/v1/events', eventsRouter)
 

--- a/routes/api/v1/olympianStats.js
+++ b/routes/api/v1/olympianStats.js
@@ -1,0 +1,41 @@
+var express = require('express');
+var router = express.Router();
+
+const environment = process.env.NODE_ENV || 'development'
+const configuration = require('../../../knexfile')[environment]
+const database = require('knex')(configuration)
+
+router.get('/', async (request, response) => {
+  const maleWeights = await database('summer_2016')
+    .groupBy('name', 'weight', 'height', 'age')
+    .where('sex', 'M')
+    .avg('weight')
+    .pluck('weight')
+
+  const femaleWeights = await database('summer_2016')
+    .groupBy('name', 'weight', 'height', 'age')
+    .where('sex', 'F')
+    .avg('weight')
+    .pluck('weight')
+
+  const ages = await database('summer_2016')
+    .groupBy('name', 'weight', 'height', 'age')
+    .pluck('age')
+
+  const average = arr => arr.reduce((a, b) => a + b, 0) / arr.length
+
+  response.status(200).json({
+    olympian_stats: {
+      total_competing_olympians: ages.length,
+      average_weight: {
+        unit: 'kg',
+        male_olympians: Math.round(average(maleWeights) * 10) / 10,
+        female_olympians: Math.round(average(femaleWeights) * 10) / 10
+      },
+      average_age: Math.round(average(ages) * 10) / 10
+    }
+  })
+
+})
+
+module.exports = router;

--- a/tests/requests/eventMedalists.spec.js
+++ b/tests/requests/eventMedalists.spec.js
@@ -8,7 +8,7 @@ const database = require('knex')(configuration);
 
 let point3
 
-describe('Test the events path', () => {
+describe('Test the event medalists path', () => {
   beforeEach(async () => {
     await database.raw('truncate table sports cascade')
     await database.raw('truncate table events cascade')

--- a/tests/requests/olympianStatsRequest.spec.js
+++ b/tests/requests/olympianStatsRequest.spec.js
@@ -9,7 +9,7 @@ const database = require('knex')(configuration);
 
 describe('Test the olympian_stats path', () => {
   beforeEach(async () => {
-    await database.raw('truncate table sumer_2016 cascade');
+    await database.raw('truncate table summer_2016 cascade');
 
     const olymp1 = {
       name: 'Moe',
@@ -71,7 +71,9 @@ describe('Test the olympian_stats path', () => {
       const response = await request(app)
         .get("/api/v1/olympian_stats")
 
-      const results = response.body.olympian_stats
+      const results = response.body
+
+      console.log(results)
 
       expect(response.statusCode).toBe(200)
 
@@ -88,8 +90,8 @@ describe('Test the olympian_stats path', () => {
       expect(results.olympian_stats.average_weight).toHaveProperty('female_olympians')
       expect(results.olympian_stats.average_weight.female_olympians).toBe(130)
 
-      expect(results).toHaveProperty('average_age')
-      expect(results.average_age).toBe(23.7)
+      expect(results.olympian_stats).toHaveProperty('average_age')
+      expect(results.olympian_stats.average_age).toBe(23.7)
     })
   })
 })

--- a/tests/requests/olympianStatsRequest.spec.js
+++ b/tests/requests/olympianStatsRequest.spec.js
@@ -1,0 +1,95 @@
+var shell = require('shelljs');
+var request = require("supertest");
+var app = require('../../app');
+
+const environment = process.env.NODE_ENV || 'test';
+const configuration = require('../../knexfile')[environment];
+const database = require('knex')(configuration);
+
+
+describe('Test the olympian_stats path', () => {
+  beforeEach(async () => {
+    await database.raw('truncate table sumer_2016 cascade');
+
+    const olymp1 = {
+      name: 'Moe',
+      sex: 'M',
+      height: 170,
+      weight: 160,
+      team: 'USA',
+      age: 29,
+      sport: 'Basketball',
+      event: '3 point contest',
+      medal: 'Gold'
+    }
+    const olymp2 = {
+      name: 'Joe',
+      sex: 'M',
+      height: 190,
+      weight: 180,
+      team: 'USA',
+      age: 20,
+      sport: 'Basketball',
+      event: '3 point contest',
+      medal: 'Silver'
+    }
+    const olymp3 = {
+      name: 'Sue',
+      sex: 'F',
+      height: 150,
+      weight: 130,
+      team: 'USA',
+      age: 22,
+      sport: 'Track',
+      event: '100 M Sprint',
+      medal: 'Gold'
+    }
+    const olymp4 = {
+      name: 'Sue',
+      sex: 'F',
+      height: 150,
+      weight: 130,
+      team: 'USA',
+      age: 22,
+      sport: 'Track',
+      event: '200 M Sprint',
+      medal: 'Silver'
+    }
+
+    await database('summer_2016').insert(olymp1, 'id')
+    await database('summer_2016').insert(olymp2, 'id')
+    await database('summer_2016').insert(olymp3, 'id')
+    await database('summer_2016').insert(olymp4, 'id')
+  })
+
+  afterEach(() => {
+    database.raw('truncate table summer_2016 cascade')
+  })
+
+  describe('test olympians_stats GET', () => {
+    it('happy path', async () => {
+      const response = await request(app)
+        .get("/api/v1/olympian_stats")
+
+      const results = response.body.olympian_stats
+
+      expect(response.statusCode).toBe(200)
+
+      expect(results.olympian_stats).toHaveProperty('total_competing_olympians')
+      expect(results.olympian_stats.total_competing_olympians).toBe(3)
+      
+      expect(results.olympian_stats).toHaveProperty('average_weight')
+      expect(results.olympian_stats.average_weight).toHaveProperty('unit')
+      expect(results.olympian_stats.average_weight.unit).toBe('kg')
+
+      expect(results.olympian_stats.average_weight).toHaveProperty('male_olympians')
+      expect(results.olympian_stats.average_weight.male_olympians).toBe(170)
+
+      expect(results.olympian_stats.average_weight).toHaveProperty('female_olympians')
+      expect(results.olympian_stats.average_weight.female_olympians).toBe(130)
+
+      expect(results).toHaveProperty('average_age')
+      expect(results.average_age).toBe(23.7)
+    })
+  })
+})


### PR DESCRIPTION
# Status
**READY TO DEPLOY**

## Migrations
NO

## Description
This PR adds the api/v1/olympian_stats endpoint and testing. All functionality is working as expected and can be merged into master. 

## Related PRs

## Todos
- [x] Testing
- [ ] Documentation


## Deploy Notes
There are slight changes to the previous migrations, make sure to rollback and then remigrate when pulling down these changes.

## Impacted Areas in Application
List general components of the application that this PR will affect:

* The `api/v1/olympian_stats` endpoint is fully functional
* All new features have been fully tested, passing travis